### PR TITLE
Update docs and types

### DIFF
--- a/lib/ecto_connection_resetter.ex
+++ b/lib/ecto_connection_resetter.ex
@@ -22,8 +22,8 @@ defmodule EctoConnectionResetter do
   @typedoc "Number of minutes between each cycle"
   @type cycle_mins :: integer()
 
-  @typedoc "Seconds to close once a disconnect_all is called"
-  @type close_interval :: integer()
+  @typedoc "Milliseconds to close once a disconnect_all is called"
+  @type close_interval :: non_neg_integer()
 
   @typedoc "Repo that will be cycled"
   @type repo :: Ecto.Repo.t()


### PR DESCRIPTION
DBConnection describes `close_interval` as milliseconds, not seconds. Also updating type to match DBConnection.